### PR TITLE
Making sure data-size="..." is used to fetch the optimized image, or use the original #17

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -34,7 +34,7 @@ export THUMBOR_SECURITY_KEY="$THUMBOR_SECURITY_KEY"
 
 ./scripts/generate-image-map.sh ./app/website-with-large-image webserver 200x ./app/unversioned/this-is-a-test2.json
 
-./scripts/generate-image-map.sh ./app/website-with-large-image webserver 500x ./app/website-with-large-image/unversioned-image-mapping.json
+./scripts/generate-image-map.sh ./app/website-with-large-image webserver 200x,x500,200x500,300x200 ./app/website-with-large-image/unversioned-image-mapping.json
 
 echo "Confirming that the unoptimized-to-optimized script works as expected"
 

--- a/website-with-large-image/image-mapping.js
+++ b/website-with-large-image/image-mapping.js
@@ -12,7 +12,7 @@
  *   mapping. For example '/unversioned-image-mapping.json'.
  * @param {string} imageSize - Image size For example '200x', '500x200', 'x250'.
  */
-function loadImages(imageServerDomain, imageFileUrl, imageSize) {
+function loadImages(imageServerDomain, imageFileUrl) {
   // Select all <img> elements in the document
   const images = document.querySelectorAll('img');
 
@@ -29,6 +29,7 @@ function loadImages(imageServerDomain, imageFileUrl, imageSize) {
           images.forEach(img => {
               // Read data attributes
               const dataSrc = img.getAttribute('data-src');
+              const dataSize = img.getAttribute('data-size');
 
               if (!dataSrc) {
                 return;
@@ -37,8 +38,8 @@ function loadImages(imageServerDomain, imageFileUrl, imageSize) {
               // Get optimized image URL from mapping data
               let optimizedSrc = mappingData[dataSrc];
 
-              if (optimizedSrc && optimizedSrc[imageSize]) {
-                secureurlpart = optimizedSrc[imageSize]
+              if (optimizedSrc && optimizedSrc[dataSize]) {
+                const secureurlpart = optimizedSrc[dataSize]
                 // Construct the optimized URL
                 const optimizedURL = `${secureurlpart}`;
 

--- a/website-with-large-image/optimized.html
+++ b/website-with-large-image/optimized.html
@@ -7,7 +7,7 @@
   <body>
     <p>This project shows how to optimize images.</p>
     <p><a href="/index.html">&gt; back home</a></p>
-    <h2>Here is an optimized image to 500px wide</h2>
+    <h2>Scroll down to see an optimized image to 200px wide</h2>
     <!--
       Instead of using the src attribute, we use data-src and data-size attributes, because the loadImages() function, below, will be
       responsible for loading an optimized version of the image, or, if

--- a/website-with-large-image/optimized.html
+++ b/website-with-large-image/optimized.html
@@ -15,21 +15,25 @@
       as displayed to the user, and data-size is the size of the image
       as requested from the optimization server.
     -->
-    <img data-src="/large-image.jpg" width="300" data-size="500x" alt="Columns in courtyard">
+    <img data-src="/large-image.jpg" data-size="500x" alt="Columns in courtyard">
     <!--
       In certain cases, an optimized image cannot be found; in such cases
       data-size is ignored, and the original image is used. In this case 300px
       is still the size of the image as displayed to the user.
     -->
-    <img data-src="/this-unversioned-large-image-is-purposefully-not-mapped.jpg" width="300" data-size="500x" alt="Elderly couple at a tourist attraction">
+    <img data-src="/this-unversioned-large-image-is-purposefully-not-mapped.jpg" data-size="500x" alt="Elderly couple at a tourist attraction">
     <!--
     -->
+
+    <img data-src="/large-image.jpg" data-size="200x" alt="Columns in courtyard">
+    <img data-src="/large-image.jpg" data-size="this-size-is-not-in-mapping" alt="Columns in courtyard">
+
     <script src="/image-mapping.js"></script>
     <script>
       // Event listener to execute loadImages function when the page is fully loaded
       window.addEventListener('load', function() {
         // http://0.0.0.0:8705 is the address of the optimization server.
-        loadImages('http://0.0.0.0:8705', '/unversioned-image-mapping.json', '500x');
+        loadImages('http://0.0.0.0:8705', '/unversioned-image-mapping.json');
       })
     </script>
   </body>

--- a/website-with-large-image/optimized.html
+++ b/website-with-large-image/optimized.html
@@ -7,7 +7,7 @@
   <body>
     <p>This project shows how to optimize images.</p>
     <p><a href="/index.html">&gt; back home</a></p>
-    <h2>Scroll down to see an optimized image to 200px wide</h2>
+    <h2>Scroll down to see an optimized image to 500x and 200px wide</h2>
     <!--
       Instead of using the src attribute, we use data-src and data-size attributes, because the loadImages() function, below, will be
       responsible for loading an optimized version of the image, or, if


### PR DESCRIPTION
* Removed hardcode image size 500x. 

* Removed inline width="300" attribute in all image tags of optimized.html. as it was overriding image width, we couldn't differentiate optimized images. hence I removed a width="300" attribute.

* Now you can see 3rd image data-size="200x" in http://0.0.0.0:8706/optimized.html page (scroll down to 3rd image) got optimized. 